### PR TITLE
Runnable jar updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ Reports can be generated for display or exported to Excel format.
 - Summarize customer visits per month for reporting
 - Summarize volunteer hours per month for reporting
 
-## To Use
-
-1. Check out source and build runnable JAR using Maven
-2. Open JAR. No login is needed.
-
 ## Developer Information
 
 All UI functionality is managed by loading an FXML file that references a specific controller.
@@ -31,6 +26,10 @@ Almost all screens are intended to display tabular data. Boilerplate for this ha
 
 Reports are also tabular in nature. `GenericReportController` manages the generic report container for all reports. A report-specific `AbstractReportStrategy` is supplied to the controller to customize the display and provide report-specific data.
 
-Input validation is managed via a series of classes in `org.pantry.food.ui.validation`. A `ValidatStatusTracker` checks to see if a given validation passes and updates the UI input control's border to red/not red depending on whether the validation was successful.
+Input validation is managed via a series of classes in `org.pantry.food.ui.validation`. A `ValidateStatusTracker` checks to see if a given validation passes and updates the UI input control's border to red/not red depending on whether the validation was successful.
 
 CSV files are read by DAOs in `org.pantry.food.dao`. Each DAO extends `AbstractCsvDao`, which abstracts the boilerplate of opening the file, reading it, mapping its data, and closing it. Each DAO acts as a template supplying DAO-specific information to AbstractCsvDao so it can properly read a specific file. Row mappers are used to translate each row of the CSV file to an model object.
+
+### Building a Distributable Jar
+
+Run `mvn package` to create a distributable fatjar. The jar includes the JFX runtime. The generated jar is located at <project root>/target.

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,44 @@
 					<release>17</release>
 				</configuration>
 			</plugin>
+			<plugin>
+				<!-- Build an executable JAR -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<mainClass>org.pantry.food.Launcher</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.5.0</version>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<mainClass>org.pantry.food.Launcher</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+				<executions>
+					<execution>
+						<id>assemble-all</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/org/pantry/food/JfxApplication.java
+++ b/src/main/java/org/pantry/food/JfxApplication.java
@@ -54,10 +54,6 @@ import javafx.stage.Stage;
  */
 public class JfxApplication extends Application {
 
-	public static void main(String[] args) {
-		Application.launch(JfxApplication.class, args);
-	}
-
 	@FXML
 	private MenuBar mnuBar;
 

--- a/src/main/java/org/pantry/food/Launcher.java
+++ b/src/main/java/org/pantry/food/Launcher.java
@@ -1,0 +1,9 @@
+package org.pantry.food;
+
+import javafx.application.Application;
+
+public class Launcher {
+	public static void main(String[] args) {
+		Application.launch(JfxApplication.class, args);
+	}
+}

--- a/src/main/java/org/pantry/food/Resources.java
+++ b/src/main/java/org/pantry/food/Resources.java
@@ -1,10 +1,13 @@
 package org.pantry.food;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.logging.log4j.LogManager;
@@ -13,20 +16,55 @@ import org.pantry.food.util.DateUtil;
 
 public class Resources {
 	private static final Logger log = LogManager.getLogger(Resources.class);
-	private final File file;
+	private Path path;
 	private Properties properties = new Properties();
 
 	public Resources() {
 		// Attempt to load the properties file
-		String path = Thread.currentThread().getContextClassLoader().getResource("").getPath()
-				+ "/application.properties";
-		file = new File(path);
+		path = null;
+
 		try {
-			properties.load(new FileInputStream(file));
+			String file = getClass().getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
+			// getPath() returns the path to the jar file. We need to strip off the
+			// filename.
+			file = file.substring(0, file.lastIndexOf("/"));
+			file += "/application.properties";
+
+			if (System.getProperty("os.name").contains("Windows") && file.charAt(0) == '/') {
+				// The leading slash returned by toURI().getPath() on Windows forks up
+				// Files.copy()
+				file = file.replaceFirst("/", "");
+			}
+			path = Path.of(file);
+
+			log.info("Looking for application.properties at {}", path);
+			// Copy application.properties to execution directory if it hasn't already been
+			// copied
+			if (!Files.exists(path)) {
+				try {
+					URL url = null;
+					ClassLoader loader = getClass().getClassLoader();
+					if (loader == null) {
+						url = ClassLoader.getSystemResource("application.properties");
+					} else {
+						url = loader.getResource("application.properties");
+					}
+//					Files.copy(Path.of(url.toURI()), new FileOutputStream(path.toFile()));
+					Files.copy(getClass().getClassLoader().getResourceAsStream("application.properties"), path);
+				} catch (IOException e) {
+					log.error("Could not copy application.properties to " + path.toString()
+							+ ". Saving settings will be disabled.", e);
+				}
+			}
+			properties.load(new FileInputStream(path.toString()));
 		} catch (FileNotFoundException e) {
 			log.error("Could not load properties from " + path, e);
 		} catch (IOException e) {
 			log.error("Could not read properties at " + path, e);
+		} catch (NullPointerException e) {
+			log.error("Could not find properties file", e);
+		} catch (URISyntaxException e) {
+			log.error(e);
 		}
 	}
 
@@ -43,8 +81,9 @@ public class Resources {
 	}
 
 	public void save() throws FileNotFoundException, IOException {
-		log.info("Saving properties file {}", file.getName());
-		properties.store(new FileOutputStream(file), "Saved at " + DateUtil.getCurrentDateStringFourDigitYear());
-		log.info("Successfully saved properties file {}", file.getName());
+		log.info("Saving properties file {}", path.getFileName());
+		properties.store(new FileOutputStream(path.toString()),
+				"Saved at " + DateUtil.getCurrentDateStringFourDigitYear());
+		log.info("Successfully saved properties file {}", path.getFileName());
 	}
 }

--- a/src/main/java/org/pantry/food/ui/dialog/AbstractController.java
+++ b/src/main/java/org/pantry/food/ui/dialog/AbstractController.java
@@ -29,7 +29,7 @@ import javafx.stage.Stage;
 
 public abstract class AbstractController<T, DIT> {
 
-	private static final Logger log = LogManager.getLogger();
+	private static final Logger log = LogManager.getLogger(AbstractController.class);
 
 	@FXML
 	protected Button addBtn;


### PR DESCRIPTION
Fixed bug that caused Log4j to throw exception on startup when NOT running in IDE. Added workaround to allow non-modular jar to be run from outside the IDE without requiring --add-modules VM argument. Added Maven plugin configuration to create a fatjar with manifest so it's runnable. Refactored the way application.properties is loaded so loading/saving works as expected outside of the IDE. Fixed typo in README.