### PR TITLE
Use underlying Java object to set default values for Visits

### DIFF
--- a/src/main/java/org/pantry/food/controller/VisitsController.java
+++ b/src/main/java/org/pantry/food/controller/VisitsController.java
@@ -17,6 +17,7 @@ import org.pantry.food.ui.dialog.AbstractController;
 import org.pantry.food.ui.dialog.AddEditVisitDialogInput;
 import org.pantry.food.util.DateUtil;
 
+import javafx.application.Platform;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -47,6 +48,9 @@ public class VisitsController extends AbstractController<Visit, AddEditVisitDial
 				LocalDate visitDate;
 				try {
 					visitDate = DateUtil.toDate(visit.getDate());
+					if (now.getYear() - visitDate.getYear() > 10) {
+						throw new IllegalArgumentException("Invalid date " + visit.getDate());
+					}
 
 					if (visit.isActive() && now.getYear() == visitDate.getYear()
 							&& now.getMonthValue() == visitDate.getMonthValue()) {
@@ -63,9 +67,18 @@ public class VisitsController extends AbstractController<Visit, AddEditVisitDial
 					}
 				} catch (ParseException e) {
 					log.error("Could not parse date " + visit.getDate(), e);
-					Alert alert = new Alert(AlertType.ERROR,
-							"Could not parse date for visit ID " + visit.getId() + ", skipping");
-					alert.show();
+					Platform.runLater(() -> {
+						Alert alert = new Alert(AlertType.ERROR,
+								"Could not parse date for visit ID " + visit.getId() + ", skipping");
+						alert.show();
+					});
+				} catch (IllegalArgumentException e) {
+					log.error(e);
+					Platform.runLater(() -> {
+						Alert alert = new Alert(AlertType.ERROR, "Could not parse date '" + visit.getDate()
+								+ "' for visit ID " + visit.getId() + ", skipping");
+						alert.show();
+					});
 				}
 
 				if (canAdd) {

--- a/src/main/java/org/pantry/food/ui/dialog/AddEditVisitDialogController.java
+++ b/src/main/java/org/pantry/food/ui/dialog/AddEditVisitDialogController.java
@@ -53,7 +53,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 
 public class AddEditVisitDialogController implements IModalDialogController<AddEditVisitDialogInput, Visit> {
-	
+
 	private static final Logger log = LogManager.getLogger(AddEditVisitDialogController.class.getName());
 
 	@FXML
@@ -87,7 +87,7 @@ public class AddEditVisitDialogController implements IModalDialogController<AddE
 
 	@FXML
 	private void initialize() {
-		
+
 		// Save button handler
 		saveBtn.setOnAction(new EventHandler<ActionEvent>() {
 
@@ -141,18 +141,17 @@ public class AddEditVisitDialogController implements IModalDialogController<AddE
 			}
 
 		});
-		
+
 		// Household combobox change event handler
-		householdIdCbo.valueProperty().addListener((ChangeListener<String>) (ov, previousValue, newValue) -> { 
+		householdIdCbo.valueProperty().addListener((ChangeListener<String>) (ov, previousValue, newValue) -> {
 			if (newValue != null) {
 				try {
-					   int num = Integer.parseInt(newValue);
-					   getHouseholdMakeup(num);
-					}
-					catch (NumberFormatException e) {
-					   log.debug("Household isn't a number");
-					}
-				
+					int num = Integer.parseInt(newValue);
+					getHouseholdMakeup(num);
+				} catch (NumberFormatException e) {
+					log.debug("Household isn't a number");
+				}
+
 			}
 		});
 
@@ -219,14 +218,16 @@ public class AddEditVisitDialogController implements IModalDialogController<AddE
 		});
 
 		// If this is a visit add, pre-select the New and Visit Date values
-		// Note: for most visits, the customers have used the pantry before. Setting new to false.
-		// Note: until the user selects a household (which will populate #kids, #adults, #seniors, set the values to 0.
+		// Note: for most visits, the customers have used the pantry before. Setting new
+		// to false.
+		// Note: until the user selects a household (which will populate #kids, #adults,
+		// #seniors, set the values to 0.
 		if (isNew) {
 			newChk.setSelected(false);
 			visitDateText.setText(DateUtil.getCurrentDateStringFourDigitYear());
-			numAdultsText.setText("0");
-			numKidsText.setText("0");
-			numSeniorsText.setText("0");
+			savedVisit.setNumberAdults(0);
+			savedVisit.setNumberKids(0);
+			savedVisit.setNumberSeniors(0);
 		}
 
 		validStatusTracker.add(householdIdCbo, newChk, numAdultsText, numKidsText, numSeniorsText, visitDateText);
@@ -281,44 +282,45 @@ public class AddEditVisitDialogController implements IModalDialogController<AddE
 			new Alert(AlertType.WARNING, "Invalid visit date").show();
 		}
 	}
-	
+
 	/**
-	 * From the household id, get the number of kids, adults and seniors. Auto-populate
-	 * the UI controls from this information.
+	 * From the household id, get the number of kids, adults and seniors.
+	 * Auto-populate the UI controls from this information.
 	 * 
 	 * @param householdId the house to look up
 	 */
 	private void getHouseholdMakeup(int householdId) {
-		
+
 		HouseholdMakeup house = new HouseholdMakeup();
-		
+
 		CustomersDao dao = ApplicationContext.getCustomersDao();
 		List<Customer> customers = dao.getAll();
-		
+
 		for (Customer customer : customers) {
-			
+
 			// TODO: any other checks need to be made here?
-			
+
 			if (customer.getHouseholdId() == householdId && customer.getAge() > -1) {
-				
+
 				if (customer.getAge() < HouseholdMakeup.AGE_ADULT) {
 					house.addChild();
-					
+
 				} else if (customer.getAge() < HouseholdMakeup.AGE_SENIOR) {
 					house.addAdult();
-					
+
 				} else {
 					house.addSenior();
 				}
-				
+
 			}
-			
+
 		}
-		
-		// set the UI text controls for number kids, adults and seniors from this information
-		this.numKidsText.setText(Integer.toString(house.getNumberChildren()));
-		this.numAdultsText.setText(Integer.toString(house.getNumberAdults()));
-		this.numSeniorsText.setText(Integer.toString(house.getNumberSeniors()));
+
+		// set the UI text controls for number kids, adults and seniors from this
+		// information
+		savedVisit.setNumberAdults(house.getNumberAdults());
+		savedVisit.setNumberKids(house.getNumberChildren());
+		savedVisit.setNumberSeniors(house.getNumberSeniors());
 	}
 
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -26,7 +26,7 @@
 		</RollingFile>
 	</Appenders>
 	<Loggers>
-		<Root level="info" additivity="false">
+		<Root level="debug" additivity="false">
 			<AppenderRef ref="console" />
 			<appender-ref ref="fileLogger" />
 		</Root>


### PR DESCRIPTION
Changed new numKids/etc defaults to 0 to use underlying Java object to avoid extra roundtrip from UI to object. There is no functional change between the two approaches.

Also added date "validation" for Visits. If the date from the CSV is technically valid (e.g. 1/2/20 is the year 20, not 2020) but more than 10 years in the past, an error prompt is shown to the user and the record is skipped. In the future we'd ideally keep the record in the UI table and highlight it red or something.